### PR TITLE
Bool query, match phrase prefix query.

### DIFF
--- a/java/src/main/kotlin/org/taymyr/lagom/elasticsearch/search/dsl/query/compound/BoolQuery.kt
+++ b/java/src/main/kotlin/org/taymyr/lagom/elasticsearch/search/dsl/query/compound/BoolQuery.kt
@@ -14,9 +14,13 @@ data class BoolQuery(val bool: BoolQueryBody) : CompoundQuery {
         private var filter: MutableList<Query> = mutableListOf()
 
         fun should(should: Query) = apply { this.should.add(should) }
+        fun should(should: List<Query>) = apply { this.should.addAll(should) }
         fun mustNot(mustNot: Query) = apply { this.mustNot.add(mustNot) }
+        fun mustNot(mustNot: List<Query>) = apply { this.mustNot.addAll(mustNot) }
         fun must(must: Query) = apply { this.must.add(must) }
+        fun must(must: List<Query>) = apply { this.must.addAll(must) }
         fun filter(filter: Query) = apply { this.filter.add(filter) }
+        fun filter(filter: List<Query>) = apply { this.filter.addAll(filter) }
 
         fun build() = BoolQuery(
             BoolQueryBody(

--- a/java/src/main/kotlin/org/taymyr/lagom/elasticsearch/search/dsl/query/fulltext/MatchPhrasePrefix.kt
+++ b/java/src/main/kotlin/org/taymyr/lagom/elasticsearch/search/dsl/query/fulltext/MatchPhrasePrefix.kt
@@ -1,3 +1,9 @@
 package org.taymyr.lagom.elasticsearch.search.dsl.query.fulltext
 
-interface MatchPhrasePrefix
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class MatchPhrasePrefix @JvmOverloads constructor(
+    val query: String,
+    @JsonProperty("max_expansions")
+    val maxExpansions: Int? = null
+)

--- a/java/src/main/kotlin/org/taymyr/lagom/elasticsearch/search/dsl/query/fulltext/MatchPhrasePrefixQuery.kt
+++ b/java/src/main/kotlin/org/taymyr/lagom/elasticsearch/search/dsl/query/fulltext/MatchPhrasePrefixQuery.kt
@@ -1,17 +1,60 @@
 package org.taymyr.lagom.elasticsearch.search.dsl.query.fulltext
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import org.taymyr.lagom.elasticsearch.search.dsl.query.Query
 
 /**
  * See [Elasticsearch Docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase-prefix.html)
  */
+@JsonSerialize(using = MatchPhrasePrefixQuery.Serializer::class)
 data class MatchPhrasePrefixQuery(
-    @JsonProperty("match_phrase_prefix")
-    val matchPhrasePrefix: MatchPhrasePrefix
+    @JsonIgnore val field: String,
+    @JsonProperty("match_phrase_prefix") val matchPhrasePrefix: MatchPhrasePrefix
 ) : Query {
+
+    class Serializer : JsonSerializer<MatchPhrasePrefixQuery>() {
+        override fun serialize(value: MatchPhrasePrefixQuery?, gen: JsonGenerator?, serializers: SerializerProvider?) {
+            gen?.run {
+                value?.let { query ->
+                    writeStartObject()
+                    writeFieldName("match_phrase_prefix")
+                    writeStartObject()
+                    writeObjectField(query.field, query.matchPhrasePrefix)
+                    writeEndObject()
+                    writeEndObject()
+                }
+            }
+        }
+    }
+
+    class Builder {
+        private var field: String? = null
+        private var query: String? = null
+        private var maxExpansions: Int? = null
+
+        fun field(field: String) = apply { this.field = field }
+        fun query(query: String) = apply { this.query = query }
+        fun maxExpansions(maxExpansions: Int) = apply { this.maxExpansions = maxExpansions }
+
+        fun build() = MatchPhrasePrefixQuery(
+            field ?: error("Field name can't be null"),
+            MatchPhrasePrefix(
+                query = query ?: error("Query can't be null"),
+                maxExpansions = maxExpansions
+            )
+        )
+    }
+
     companion object {
         @JvmStatic
-        fun of(matchPhrasePrefix: MatchPhrasePrefix) = MatchPhrasePrefixQuery(matchPhrasePrefix)
+        fun builder() = Builder()
+
+        @JvmStatic
+        fun of(field: String, query: String) = MatchPhrasePrefixQuery(field, MatchPhrasePrefix(query))
     }
 }

--- a/java/src/test/java/org/taymyr/lagom/elasticsearch/search/dsl/query/compound/CompoundTest.java
+++ b/java/src/test/java/org/taymyr/lagom/elasticsearch/search/dsl/query/compound/CompoundTest.java
@@ -1,9 +1,11 @@
 package org.taymyr.lagom.elasticsearch.search.dsl.query.compound;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.taymyr.lagom.elasticsearch.search.dsl.SearchRequest;
 import org.taymyr.lagom.elasticsearch.search.dsl.query.term.IdsQuery;
+import org.taymyr.lagom.elasticsearch.search.dsl.query.term.TermQuery;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.taymyr.lagom.elasticsearch.Helpers.resourceAsString;
@@ -56,6 +58,23 @@ class CompoundTest {
             .build();
         String actual = serializeRequest(request, SearchRequest.class);
         String expected = resourceAsString("org/taymyr/lagom/elasticsearch/search/dsl/query/compound/request_filter.json");
+        assertThatJson(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("successfully serialize search request with list of conditions")
+    void shouldSuccessfullySerializeMustBoolQueryWithList() {
+        SearchRequest request = SearchRequest.builder()
+                .query(BoolQuery.builder()
+                        .filter(ImmutableList.of(IdsQuery.of("1"), TermQuery.of("names", "name1")))
+                        .must(ImmutableList.of(IdsQuery.of("1"), TermQuery.of("names", "name1")))
+                        .mustNot(ImmutableList.of(IdsQuery.of("1"), TermQuery.of("names", "name1")))
+                        .should(ImmutableList.of(IdsQuery.of("1"), TermQuery.of("names", "name1")))
+                        .build())
+                .size(9999)
+                .build();
+        String actual = serializeRequest(request, SearchRequest.class);
+        String expected = resourceAsString("org/taymyr/lagom/elasticsearch/search/dsl/query/compound/request_condition_list.json");
         assertThatJson(actual).isEqualTo(expected);
     }
 

--- a/java/src/test/resources/org/taymyr/lagom/elasticsearch/search/dsl/query/compound/request_condition_list.json
+++ b/java/src/test/resources/org/taymyr/lagom/elasticsearch/search/dsl/query/compound/request_condition_list.json
@@ -1,0 +1,71 @@
+{
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "ids": {
+            "values": [
+              "1"
+            ]
+          }
+        },
+        {
+          "term": {
+            "names": {
+              "value": "name1"
+            }
+          }
+        }
+      ],
+      "must": [
+        {
+          "ids": {
+            "values": [
+              "1"
+            ]
+          }
+        },
+        {
+          "term": {
+            "names": {
+              "value": "name1"
+            }
+          }
+        }
+      ],
+      "must_not": [
+        {
+          "ids": {
+            "values": [
+              "1"
+            ]
+          }
+        },
+        {
+          "term": {
+            "names": {
+              "value": "name1"
+            }
+          }
+        }
+      ],
+      "should": [
+        {
+          "ids": {
+            "values": [
+              "1"
+            ]
+          }
+        },
+        {
+          "term": {
+            "names": {
+              "value": "name1"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "size": 9999
+}

--- a/java/src/test/resources/org/taymyr/lagom/elasticsearch/search/dsl/query/fulltext/match_phrase_prefix.json
+++ b/java/src/test/resources/org/taymyr/lagom/elasticsearch/search/dsl/query/fulltext/match_phrase_prefix.json
@@ -4,7 +4,9 @@
       "filter": [
         {
           "match_phrase_prefix": {
-            "field": "value"
+            "field": {
+              "query": "value"
+            }
           }
         }
       ]


### PR DESCRIPTION
Bool query: new overloaded methods that add lists of filters (must, must not, should, filter). Match phrase prefix query: simplified, now it has 'of' method than constructs filter, so you shouldn`t implement match phrase prefix interface in custom class.